### PR TITLE
Add support for custom ChatGPT model selection and arm64-darwin platforms

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,6 +122,8 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.9)
+    nokogiri (1.14.3-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.14.3-x86_64-darwin)
       racc (~> 1.4)
     pastel (0.8.0)
@@ -168,6 +170,7 @@ GEM
       faraday (>= 1)
       faraday-multipart (>= 1)
     ruby2_keywords (0.0.5)
+    sqlite3 (1.6.2-arm64-darwin)
     sqlite3 (1.6.2-x86_64-darwin)
     strings (0.2.1)
       strings-ansi (~> 0.2)
@@ -200,6 +203,7 @@ GEM
     zeitwerk (2.6.7)
 
 PLATFORMS
+  arm64-darwin
   x86_64-darwin-21
 
 DEPENDENCIES

--- a/bin/ask_chatgpt
+++ b/bin/ask_chatgpt
@@ -21,6 +21,7 @@ parser = OptionParser.new do |opts|
 
     Examples:
       ask_chatgpt -q "How to parse JSON file in Ruby?"
+      ask_chatgpt -m gpt-4 -q "How to parse JSON file in Ruby?"
       ask_chatgpt -f app/models/user.rb -q "find a bug in this Rails model"
       ask_chatgpt -f app/models/user.rb -q "create RSpec spec for this model"
       ask_chatgpt -f test/dummy/Gemfile -q "sort Ruby gems alphabetically"
@@ -42,6 +43,10 @@ parser = OptionParser.new do |opts|
     options[:file_path] = file
   end
 
+  opts.on("-m", "--model MODEL", String, "Specify the ChatGPT model. Uses \"gpt-3.5-turbo\" by default") do |model|
+    options[:model] = model
+  end
+
   opts.on("-d", "--debug", "Output request/response") do |debug|
     options[:debug] = true
   end
@@ -55,6 +60,8 @@ end
 parser.parse!
 
 AskChatGPT.debug = !!options[:debug]
+
+AskChatGPT.model = options[:model] if options[:model].present?
 
 options[:prompt] = ARGV.join(" ") if options[:prompt].blank?
 


### PR DESCRIPTION
- Update the bin/ask_chatgpt script to include a new command-line option -m or --model that allows users to specify the  ChatGPT model.
- Add support for the arm64-darwin platform in the Gemfile.lock file. This allows the application to run on Apple Silicon (M1) machines without any compatibility issues.